### PR TITLE
Add GitHubPullRequest class

### DIFF
--- a/lib/github_pull_request.rb
+++ b/lib/github_pull_request.rb
@@ -1,0 +1,49 @@
+require 'octokit'
+require_relative 'pivotal_poster'
+require 'net/http'
+
+class GitHubPullRequest
+  attr_reader :login_user, :pivotal_poster
+
+  def initialize(repo, pull_request_id, pivotal_poster)
+    @login_user = authenticate
+    @pivotal_poster = pivotal_poster
+    fetch_pull_request_data(repo, pull_request_id)
+  end
+
+  def fetch_pull_request_data(repo, pull_request_id)
+    pull_request = login_user.pull_request(repo, pull_request_id)
+    unless pull_request.body.empty?
+      check_for_pivotal_story(pull_request.html_url, pull_request.body)
+    end
+  end
+
+private
+
+  def authenticate
+    @login_user = Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
+  end
+
+  def check_for_pivotal_story(pr_url, pr_body)
+    pivotal_story_url = pr_body.match(%r{https://www.pivotaltracker.com/story/show/\w{9}})
+    if pivotal_story_url
+      full_pivotal_url = get_full_pivotal_url(pivotal_story_url)
+      ids = extract_ids(full_pivotal_url)
+      post_to_pivotal(ids[-3].to_i, ids[-1].to_i, pr_url)
+    end
+  end
+
+  def extract_ids(pivotal_url)
+    pivotal_url.split('/')
+  end
+
+  def get_full_pivotal_url(url)
+    uri = URI(url[0])
+    res = Net::HTTP.get_response(uri)
+    res['location']
+  end
+
+  def post_to_pivotal(project_id, story_id, pr_url)
+    pivotal_poster.post(project_id, story_id, pr_url)
+  end
+end

--- a/lib/pivotal_poster.rb
+++ b/lib/pivotal_poster.rb
@@ -1,13 +1,16 @@
 require 'pivotal-tracker'
 
 class PivotalPoster
-  attr_reader :project, :story, :pr_url
+  attr_reader :project, :story
 
-  def initialize(project_id, story_id, pr_url)
-    authenticate
+  def initialize(api_token)
+    PivotalTracker::Client.token = api_token
+  end
+
+  def post(project_id, story_id, pr_url)
     @project ||= retrieve_project(project_id)
     @story ||= retrieve_story(story_id)
-    @pr_url = pr_url
+    post_github_pr_url(pr_url)
   end
 
   def retrieve_project(project_id)
@@ -18,13 +21,10 @@ class PivotalPoster
     project.stories.find(story_id)
   end
 
-  def post_github_pr_url
-    story.notes.create(text: "#{pr_url}")
-  end
 
 private
 
-  def authenticate
-    PivotalTracker::Client.token = ENV['PIVOTAL_API_TOKEN']
+  def post_github_pr_url(pr_url)
+    story.notes.create(text: "#{pr_url}")
   end
 end

--- a/spec/features/pr_poster_spec.rb
+++ b/spec/features/pr_poster_spec.rb
@@ -1,0 +1,20 @@
+require 'github_pull_request'
+
+describe 'Pull Request Poster' do
+
+  it 'posts a pull request URL to the Trello card referenced in its commit message' do
+    pivotal_poster = PivotalPoster.new(ENV['PIVOTAL_API_TOKEN'])
+    github_pr = GitHubPullRequest.new(60356290, 4, pivotal_poster)
+    pull_request = github_pr.login_user.pull_request(60356290, 4)
+    PivotalTracker::Client.token = ENV['PIVOTAL_API_TOKEN']
+    project = PivotalTracker::Project.find(1788875)
+    story = project.stories.find(128659665)
+    expect(story.notes.all.first.text).to eq(pull_request.html_url)
+    story.notes.all.delete(story.notes.all.first)
+  end
+
+  xit 'does not post a pull request URL to a Trello card if it already exists in the card\'s PR checklist' do
+    GitHubPullRequest.new(60356290, 1, pivotal_poster)
+    expect(@checklist.check_items.count).to eq(1)
+  end
+end

--- a/spec/github_pull_request_spec.rb
+++ b/spec/github_pull_request_spec.rb
@@ -1,0 +1,33 @@
+require 'github_pull_request'
+require 'ostruct'
+
+describe GitHubPullRequest do
+  let(:pivotal_poster) { double(PivotalPoster) }
+  let(:repo_pull_request) do
+    OpenStruct.new({
+      html_url: 'https://github.com/gov-test-org/project-b/pull/1',
+      body: 'A commit with a PivotalTracker URL https://www.pivotaltracker.com/story/show/128659665'
+    })
+  end
+  let(:octokit) { double Octokit::Client, login: 'username', pull_request: repo_pull_request }
+  subject(:github_pr) { GitHubPullRequest.new(60356369, 1, pivotal_poster) }
+
+  before(:each) do
+    allow(Octokit::Client).to receive(:new).and_return(octokit)
+    allow(pivotal_poster).to receive(:post)
+  end
+
+  describe 'Default' do
+    it 'initializes with login_user set to an authenticated Github user' do
+      expect(github_pr.login_user).to have_attributes(login: 'username')
+    end
+
+  end
+
+  describe '#fetch_pull_request_data' do
+    it 'retrieves HTML URL and body data for the given URL and passes to the check_for_trello_card method, leading to GitHubPullRequest being instantiated' do
+      expect(pivotal_poster).to receive(:post).with(1788875, 128659665, 'https://github.com/gov-test-org/project-b/pull/1')
+      GitHubPullRequest.new(60356369, 1, pivotal_poster)
+    end
+  end
+end

--- a/spec/pivotal_poster_spec.rb
+++ b/spec/pivotal_poster_spec.rb
@@ -1,26 +1,26 @@
 require 'pivotal_poster'
 
 describe PivotalPoster do
-  let(:pivotal_poster) { PivotalPoster.new(1788875, 128659665, 'https://github.com/gov-test-org/project-b/pull/1') }
+  let(:pivotal_poster) { PivotalPoster.new(ENV['PIVOTAL_API_TOKEN']) }
 
   let(:pivotal_project) do
-    instance_double("PivotalTracker::Project",
-                    id: 1788875,
-                    stories: [])
+    double("PivotalTracker::Project",
+            id: 1788875,
+            stories: [])
   end
 
   let(:pivotal_story) do
-    instance_double("PivotalTracker::Story",
-                    id: 128659665,
-                    notes: instance_double("PivotalTracker::Note", create: story_note))
+    double("PivotalTracker::Story",
+            id: 128659665,
+            notes: double("PivotalTracker::Note", create: story_note))
   end
 
-  let(:story_note) { instance_double("PivotalTracker::Note") }
+  let(:story_note) { double("PivotalTracker::Note") }
 
   before(:each) do
     allow(PivotalTracker::Project).to receive(:find).with(1788875).and_return(pivotal_project)
     allow(pivotal_project.stories).to receive(:find).with(128659665).and_return(pivotal_story)
-    allow(pivotal_story.notes).to receive(:create).and_return(story_note)
+    pivotal_poster.post(1788875, 128659665, 'https://github.com/gov-test-org/project-b/pull/1')
   end
 
   describe '#retrieve_project' do
@@ -32,13 +32,6 @@ describe PivotalPoster do
   describe '#retrieve_story' do
     it 'retrieves the correct PivotalTracker story' do
       expect(pivotal_poster.story).to eq(pivotal_story)
-    end
-  end
-
-  describe '#post_github_pr_url' do
-    xit 'posts a GitHub Pull Request URL to a PivotalTracker story' do
-      pivotal_poster.post_github_pr_url
-      expect(pivotal_story.notes).to have_received(:create)
     end
   end
 end


### PR DESCRIPTION
- This handles processing a GitHub pull request and extracting the necessary information to be posted to PivotalTracker using the PivotalPoster class.
- A 'post' method has been added to the PivotalPoster class to handle all methods that enable Pull Request URLs to be posted to PivotalTracker stories.  A new instance of PivotalTracker is passed into GitHubPullRequest and then the post method is called once the necessary information has been extracted.
- A Pivotal Poster spec file has been created to test how the two classes work together.