### PR TITLE
Prevent from posting duplicate Pull Request URLs to Pivotal

### DIFF
--- a/lib/pivotal_poster.rb
+++ b/lib/pivotal_poster.rb
@@ -21,10 +21,17 @@ class PivotalPoster
     project.stories.find(story_id)
   end
 
-
 private
 
   def post_github_pr_url(pr_url)
-    story.notes.create(text: "#{pr_url}")
+    unless pr_url_is_present?(pr_url)
+      story.notes.create(text: "#{pr_url}")
+    end
+  end
+
+  def pr_url_is_present?(pr_url)
+    story.notes.all.detect do |note|
+      note.text == pr_url
+    end
   end
 end

--- a/spec/features/pr_poster_spec.rb
+++ b/spec/features/pr_poster_spec.rb
@@ -3,8 +3,8 @@ require 'github_pull_request'
 describe 'Pull Request Poster' do
 
   it 'posts a pull request URL to the Trello card referenced in its commit message' do
-    pivotal_poster = PivotalPoster.new(ENV['PIVOTAL_API_TOKEN'])
-    github_pr = GitHubPullRequest.new(60356290, 4, pivotal_poster)
+    @pivotal_poster = PivotalPoster.new(ENV['PIVOTAL_API_TOKEN'])
+    github_pr = GitHubPullRequest.new(60356290, 4, @pivotal_poster)
     pull_request = github_pr.login_user.pull_request(60356290, 4)
     PivotalTracker::Client.token = ENV['PIVOTAL_API_TOKEN']
     project = PivotalTracker::Project.find(1788875)
@@ -13,8 +13,10 @@ describe 'Pull Request Poster' do
     story.notes.all.delete(story.notes.all.first)
   end
 
-  xit 'does not post a pull request URL to a Trello card if it already exists in the card\'s PR checklist' do
-    GitHubPullRequest.new(60356290, 1, pivotal_poster)
-    expect(@checklist.check_items.count).to eq(1)
+  it 'does not post a pull request URL to a Pivotal story if it already exists in the story\'s notes' do
+    GitHubPullRequest.new(60356290, 1, @pivotal_poster)
+    project = PivotalTracker::Project.find(1788875)
+    story = project.stories.find(128659665)
+    expect(story.notes.all.count).to eq(1)
   end
 end

--- a/spec/pivotal_poster_spec.rb
+++ b/spec/pivotal_poster_spec.rb
@@ -20,6 +20,8 @@ describe PivotalPoster do
   before(:each) do
     allow(PivotalTracker::Project).to receive(:find).with(1788875).and_return(pivotal_project)
     allow(pivotal_project.stories).to receive(:find).with(128659665).and_return(pivotal_story)
+    allow(pivotal_story.notes).to receive(:all)
+    allow(pivotal_story.notes.all).to receive(:detect).and_return(false)
     pivotal_poster.post(1788875, 128659665, 'https://github.com/gov-test-org/project-b/pull/1')
   end
 
@@ -34,4 +36,5 @@ describe PivotalPoster do
       expect(pivotal_poster.story).to eq(pivotal_story)
     end
   end
+
 end


### PR DESCRIPTION
- We have added a guard clause to check if a pull request URL is already present in a PivotalTracker story's notes.  If the URL is already present, then it won't be posted again.